### PR TITLE
Support more request options

### DIFF
--- a/lib/find-rss.js
+++ b/lib/find-rss.js
@@ -15,16 +15,22 @@
 
   module.exports = finder = function(req, callback) {
     var body, candidates, urlObject;
+    if (typeof req === "string") {
+      req = {
+        url: req
+      };
+    }
+    req.encoding = null;
     if (finder.favicon == null) {
       finder.favicon = true;
     }
     if (finder.getDetail == null) {
       finder.getDetail = false;
     }
-    if (!/^https?/.test(req)) {
+    if (!/^https?/.test(req.url)) {
       return callback(new Error("Not HTTP URL is provided."), null);
     }
-    urlObject = url.parse(req);
+    urlObject = url.parse(req.url);
     body = "";
     candidates = [];
     return async.series([
@@ -49,7 +55,7 @@
         for (i = 0, len = candidates.length; i < len; i++) {
           cand = candidates[i];
           if (cand.link != null) {
-            cand.url = req;
+            cand.url = req.url;
             cand.sitename = cand.title;
           } else {
             if (/^https?/.test(cand.href)) {
@@ -70,7 +76,8 @@
         }
         newCandidates = [];
         return async.forEach(candidates, function(cand, _cb) {
-          return requestAndEncodeWithDetectCharset(cand.url, function(err, body) {
+          req.url = cand.url;
+          return requestAndEncodeWithDetectCharset(req, function(err, body) {
             if (err) {
               return _cb();
             }
@@ -142,11 +149,8 @@
     }
   };
 
-  requestAndEncodeWithDetectCharset = function(url, callback) {
-    return request.get({
-      uri: url,
-      encoding: null
-    }, function(err, res, body) {
+  requestAndEncodeWithDetectCharset = function(req, callback) {
+    return request.get(req, function(err, res, body) {
       var charset;
       if (err) {
         return callback(err, null);


### PR DESCRIPTION
Some RSS need more request options to fetch, such as:

- Apple RSS need normal browser UA
- Private RSS need auth 
- Intern RSS need proxy
- and so on...

So I extend req as request options to handle more