### PR TITLE
use "url.resolve" to join hostname and path

### DIFF
--- a/src/find-rss.coffee
+++ b/src/find-rss.coffee
@@ -56,7 +56,7 @@ module.exports = finder = (req,callback)->
         if /^https?/.test cand.href
           cand.url = cand.href
         else
-          cand.url = "#{urlObject.protocol}//#{urlObject.host}#{cand.href}"
+          cand.url = url.resolve "#{urlObject.protocol}//#{urlObject.host}", cand.href
     cb()
 
   ,(cb)->


### PR DESCRIPTION
fixed #23

`url.resolve` resolves relative path.