### PR TITLE
Hotfix: multiple calls to error callback

### DIFF
--- a/src/find-rss.coffee
+++ b/src/find-rss.coffee
@@ -64,7 +64,7 @@ _finder = (req,callback)->
 
         if /^https?/.test cand.href
           cand.url = cand.href
-        else
+        else if cand.href?
           cand.url = url.resolve "#{urlObject.protocol}//#{urlObject.host}", cand.href
     cb()
 

--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -77,8 +77,9 @@ module.exports = exports = (htmlBody,callback)->
     feedparser = new FeedParser()
     candidates = []
 
-    feedparser.on 'error',(error)->
-      return callback error,null
+    feedparser.on 'error',(err)->
+      # FeedParserの仕様的にerrorは複数回発生するため、error発生時はendをemitして終了させる
+      this.emit 'end',err
 
     feedparser.on 'readable',->
       if candidates.length is 0
@@ -86,7 +87,8 @@ module.exports = exports = (htmlBody,callback)->
         candidates.push data
 
     feedparser.write htmlBody
-    feedparser.end ->
+    feedparser.end (err)->
+      return callback err if err
       return callback null,candidates
 
   else
@@ -96,6 +98,3 @@ module.exports = exports = (htmlBody,callback)->
       cand.favicon  = favicon
 
     return callback null,candidates
-
-
-


### PR DESCRIPTION
feedparserの仕様上parse時にerrorは複数回呼ばれ、既存の実装だと都度callbackを返していたため`Uncaught Error: Callback was already called.`が発生していました。
そのためparseエラー時はこちらから`end`をemitし、ただ一度だけcallbackが呼ばれる実装に変更しました。