### PR TITLE
Hotfix: not fired callback on favicon request

### DIFF
--- a/src/find-rss.coffee
+++ b/src/find-rss.coffee
@@ -119,7 +119,7 @@ _finder = (req,callback)->
       else
         guess = "#{urlObject.protocol}//#{urlObject.host}/favicon.ico"
         request guess, (err,res,body)->
-          return _cb if err or res?.statusCode isnt 200
+          return _cb() if err or res?.statusCode isnt 200
           cand.favicon = guess
           _cb()
     ,->


### PR DESCRIPTION
関数呼び出しになってなかったので修正しました。
faviconの取得に失敗していたとしてもcandidatesの取得には成功している場合があるため、errorは返さずにasyncのcallbackを呼んでます。