### PR TITLE
Hotfix: dealing with iconv-lite unsupported encoding error

### DIFF
--- a/src/find-rss.coffee
+++ b/src/find-rss.coffee
@@ -148,7 +148,10 @@ requestAndEncodeWithDetectCharset = (req,callback)->
       return callback new Error('NotFoundEncodingError'),null
 
     if charset isnt ('utf-8' or 'UTF-8')
-      body = iconv.decode(body, charset)
+      try
+        body = iconv.decode(body, charset)
+      catch error
+        return callback error,null
 
     return callback null,body
   .on 'data', (chunk)->


### PR DESCRIPTION
対象ページが`ISO-2022-JP`などの文字コードの場合、iconv-liteが対応していないためErrorとなります。
現状このエラーをハンドルしていなかったので修正しました。